### PR TITLE
Fix: -l switch does not work

### DIFF
--- a/copyright/cli.py
+++ b/copyright/cli.py
@@ -61,7 +61,6 @@ copyright -c options.json file1 dir2/*
             help='Number of newlines before/after injected message.')
         parser.add_argument(
             '-l', '--license',
-            action='append',
             choices=sorted(copyright.template.Template.DEFAULT.keys()),
             help='''License.''')
         parser.add_argument(


### PR DESCRIPTION
Without this pull request, the -l CLI switch causes an error:

```
Traceback (most recent call last):
  File "/usr/lib/python2.7/runpy.py", line 174, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.7/runpy.py", line 72, in _run_code
    exec code in run_globals
  File "/home/sam/.local/lib/python2.7/site-packages/copyright/app.py", line 64, in <module>
    if '__main__' == __name__: main()
  File "/home/sam/.local/lib/python2.7/site-packages/copyright/app.py", line 62, in main
    sys.exit(App.main(sys.argv[1:]))
  File "/home/sam/.local/lib/python2.7/site-packages/copyright/app.py", line 20, in main
    return app.run()
  File "/home/sam/.local/lib/python2.7/site-packages/copyright/app.py", line 57, in run
    self.process(file)
  File "/home/sam/.local/lib/python2.7/site-packages/copyright/app.py", line 29, in process
    text = copyright.License(self.config).text
  File "/home/sam/.local/lib/python2.7/site-packages/copyright/license.py", line 5, in __init__
    temp = config.dict.get('templates')[config.license]
TypeError: unhashable type: 'list'

```